### PR TITLE
プレイヤーがスライムに攻撃するとスライムは無敵状態になり一定時間経過すると無敵状態が解除され4回攻撃がヒットするとスライムが消えるようになりました。

### DIFF
--- a/src/main/java/entity/Entity.java
+++ b/src/main/java/entity/Entity.java
@@ -401,7 +401,7 @@ public class Entity {
             }
 
             g2.drawImage(image, screenX, screenY, FrameApp.getTileSize(), FrameApp.getTileSize(), null);
-            
+
             g2.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 1f));
         }
     }

--- a/src/main/java/monster/MonGreenSlime.java
+++ b/src/main/java/monster/MonGreenSlime.java
@@ -9,7 +9,6 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Random;
 
 public class MonGreenSlime extends Entity {
@@ -24,8 +23,6 @@ public class MonGreenSlime extends Entity {
     private BufferedImage[][] sprites = new BufferedImage[DIRECTIONS.length][SPRITE_COUNT];
     private Random random = new Random();
     private int actionLockCounter = 0;
-    private boolean invincible = false;
-    private int invincibleCounter = 0;
 
     public MonGreenSlime(GameWindow gameWindow) {
         super(gameWindow);
@@ -74,6 +71,8 @@ public class MonGreenSlime extends Entity {
 
     public void setAction() {
 
+        updateMonsterInvincibility();
+
         actionLockCounter++;
 
         if (actionLockCounter >= ACTION_LOCK_THRESHOLD) {
@@ -88,6 +87,20 @@ public class MonGreenSlime extends Entity {
                 setDirection("right");
             }
             actionLockCounter = 0;
+        }
+    }
+
+    private void updateMonsterInvincibility() {
+        if (getInvincible()) {
+            setInvincibleCounter(getInvincibleCounter() + 1);
+            System.out.println("getInvincibleCounter() :" + getInvincibleCounter());
+            if (getInvincibleCounter() > 40) {
+                System.out.println("getInvincibleCounter() :" + getInvincibleCounter());
+                setInvincible(false);
+                System.out.println("スライムの無敵状態が解除されました。");
+                System.out.println("getInvincible() :" + getInvincible());
+                setInvincibleCounter(0);
+            }
         }
     }
 }

--- a/src/main/java/player/Player.java
+++ b/src/main/java/player/Player.java
@@ -233,8 +233,6 @@ public class Player extends Entity {
         setSpriteCounter(0);
         setAttacking(false);
         setSpriteNum(1);
-
-        updateMonsterInvincibility();
     }
 
     public void interactNPC(int i) {
@@ -279,20 +277,6 @@ public class Player extends Entity {
                 if (gameWindow.getMonster()[i].getLife() <= 0) {
                     gameWindow.getMonster()[i] = null;
                 }
-            }
-        }
-    }
-
-    private void updateMonsterInvincibility() {
-        if (getInvincible()) {
-            setInvincibleCounter(getInvincibleCounter() + 1);
-            System.out.println("getInvincibleCounter() :" + getInvincibleCounter());
-            if (getInvincibleCounter() > 40) {
-                System.out.println("getInvincibleCounter() :" + getInvincibleCounter());
-                setInvincible(false);
-                System.out.println("スライムの無敵状態が解除されました。");
-                System.out.println("getInvincible() :" + getInvincible());
-                setInvincibleCounter(0);
             }
         }
     }


### PR DESCRIPTION
# プレイヤーがスライムに攻撃して,一定時間経っても無敵時間が解除されない問題解決

プレイヤークラスにプレイヤーが攻撃したときにスライムの無敵状態を管理するフラグを書いていたのですが,プレイヤークラスに管理されている無敵状態はプレイヤーでしか管理されていなかったため,プレイヤーが攻撃してもスライムの無敵状態は攻撃がヒットしたときに無敵状態になったまま一定時間経過しても解除されませんでした。
![image](https://github.com/user-attachments/assets/7ca3957d-eebc-48f1-9442-588497b825ff)

# 解決
# MonGreenSlimeクラスでスライムの無敵状態を管理するようにしました。

![スクリーンショット 2025-05-20 230346](https://github.com/user-attachments/assets/cbacaac9-5d57-4441-bbea-81b5f7803cf2)
