### PR TITLE
プレイヤーがレベル上がったときにスライムの石ころの衝突判定はあるが,プレイヤーの体力が減らない問題を解決しました。

### DIFF
--- a/src/main/java/entity/Entity.java
+++ b/src/main/java/entity/Entity.java
@@ -536,24 +536,12 @@ public abstract class Entity {
         this.respawning = respawning;
     }
 
-    public boolean isVisible() {
-        return visible;
-    }
-
-    public void setVisible(boolean visible) {
-        this.visible = visible;
-    }
-
     public String getDescription() {
         return description;
     }
 
     public void setDescription(String description) {
         this.description = description;
-    }
-
-    public int getUseCost() {
-        return useCost;
     }
 
     public void setUseCost(int useCost) {
@@ -590,14 +578,6 @@ public abstract class Entity {
 
     public void setMana(int mana) {
         this.mana = mana;
-    }
-
-    public int getCollisionCooldown() {
-        return collisionCooldown;
-    }
-
-    public void setCollisionCooldown(int collisionCooldown) {
-        this.collisionCooldown = collisionCooldown;
     }
 
     public int getType_pickupOnly() {

--- a/src/main/java/object/Projectile.java
+++ b/src/main/java/object/Projectile.java
@@ -2,8 +2,6 @@ package object;
 
 import collision.CollisionChecker;
 import entity.Entity;
-import frame.FrameApp;
-import player.Player;
 import window.GameWindow;
 
 import java.awt.*;
@@ -43,53 +41,30 @@ public abstract class Projectile extends Entity {
 
         GameWindow gw = getGameWindow();
         CollisionChecker cc = gw.getCollisionChecker();
-        Player p = gw.getPlayer();
-
-        // 1) プレイヤーの当たり判定矩形（ワールド座標）
-        Rectangle playerArea = new Rectangle(
-                p.getWorldX() + p.getSolidArea().x,
-                p.getWorldY() + p.getSolidArea().y,
-                p.getSolidArea().width,
-                p.getSolidArea().height
-
-        );
-
-        // 2) この石ころ（Projectile）の当たり判定矩形
-        Rectangle stoneArea = new Rectangle(
-                getWorldX() + getSolidArea().x,
-                getWorldY() + getSolidArea().y,
-                getSolidArea().width,
-                getSolidArea().height
-        );
-
-        // 3) 重なりチェック
-        boolean overlap = playerArea.intersects(stoneArea);
-        System.out.printf(
-                "[DBG] playerArea=%s, stoneArea=%s, overlap=%b%n",
-                playerArea, stoneArea, overlap
-        );
 
         move();
 
-        if (user == getGameWindow().getPlayer()) {
-            int monsterIndex = getGameWindow().getCollisionChecker().checkEntity(this, getGameWindow().getMonster());
-            if (monsterIndex != 999) {
-                getGameWindow().getPlayer().damageMonster(monsterIndex, getAttack());
-                setAlive(false);
-            }
-        } else {
-            boolean contactPlayer = getGameWindow().getCollisionChecker().checkPlayer(this);
-            System.out.printf("[DBG] cc.checkPlayer() → %b%n", contactPlayer);
-            System.out.println("Invincible = " + getInvincible());
-            System.out.println("contactPlayer = " + contactPlayer);
-            if (getGameWindow().getPlayer().getInvincible() == false && contactPlayer == true) {
-                damagePlayer(getAttack());
-                System.out.println("プレイヤ-に石ころの衝突判定がありダメージを与えた!");
-                setAlive(false);
+        // Entity間とPlayer間の衝突チェック
+        if (this instanceof Projectile proj) {
+
+            // 発射元によって判定先を切り分け
+            if (proj.user == getGameWindow().getPlayer()) {
+                int mi = cc.checkEntity(proj, getGameWindow().getMonster());
+                if (mi != 999) {
+                    getGameWindow().getPlayer().damageMonster(mi, proj.getAttack());
+                    setAlive(false);
+                }
+            } else {
+                boolean hit = cc.checkPlayer(proj);
+                if (hit && !getGameWindow().getPlayer().getInvincible()) {
+                    getGameWindow().getPlayer().damagePlayer(proj.getAttack());
+                    setAlive(false);
+                }
             }
         }
         updateAnimation();
     }
+
 
     protected void move() {
         switch (getDirection()) {
@@ -123,21 +98,22 @@ public abstract class Projectile extends Entity {
                     + getGameWindow().getPlayer().getScreenY();
             g2.drawImage(image, screenX, screenY, null);
 
-            // --- ここからデバッグ描画 ---
-            if (getGameWindow().isShowHitBoxes()) {
-                // 当たり判定領域をスクリーン座標に変換
-                int x = screenX + getSolidArea().x;
-                int y = screenY + getSolidArea().y;
-                int w = getSolidArea().width;
-                int h = getSolidArea().height;
-
-                // 色や線幅を設定して描画
-                g2.setColor(new Color(255, 0, 0, 180));      // 半透明の赤
-                g2.setStroke(new BasicStroke(2));
-                g2.drawRect(x, y, w, h);
-
-                g2.drawImage(image, screenX, screenY, FrameApp.getTileSize(), FrameApp.getTileSize(), null);
-            }
+            // デバッグ
+//            if (getGameWindow().isShowHitBoxes()) {
+//                // 当たり判定領域をスクリーン座標に変換
+//                int x = screenX + getSolidArea().x;
+//                int y = screenY + getSolidArea().y;
+//                int w = getSolidArea().width;
+//                int h = getSolidArea().height;
+//
+//                // 色や線幅を設定して描画
+//                g2.setColor(new Color(255, 0, 0, 180));
+//                g2.setStroke(new BasicStroke(2));
+//                g2.drawRect(x, y, w, h);
+//
+//                g2.drawImage(image, screenX, screenY, FrameApp.getTileSize(), FrameApp.getTileSize(), null);
+//            }
+//        }
         }
     }
 }

--- a/src/main/java/player/Player.java
+++ b/src/main/java/player/Player.java
@@ -97,8 +97,8 @@ public class Player extends Entity {
         setCurrentWeapon(new ObjSwordNormal(gameWindow));
         setCurrentShield(new ObjShieldWood(gameWindow));
         setProjectile(new ObjFireball(gameWindow));
-        setAttack(getAttack());
-        setDefense(getDefense());
+        setAttack(calculateBaseAttack());
+        setDefense(calculateBaseDefense());
     }
 
     public void setItems() {
@@ -127,16 +127,6 @@ public class Player extends Entity {
         inventory.add(new ObjGreenPotion(gameWindow));
         inventory.add(new ObjGreenPotion(gameWindow));
         inventory.add(new ObjGreenPotion(gameWindow));
-    }
-
-    @Override
-    public int getAttack() {
-        return setAttack(getStrength() * getCurrentWeapon().getAttackValue());
-    }
-
-    @Override
-    public int getDefense() {
-        return setDefense(getDexterity() * getCurrentShield().getDefenseValue());
     }
 
     public void loadPlayerImages() {
@@ -392,7 +382,7 @@ public class Player extends Entity {
         getSolidArea().height = FrameApp.getTileSize();
 
         int monsterIndex = gameWindow.getCollisionChecker().checkEntity(this, gameWindow.getMonster());
-        damageMonster(monsterIndex, getAttack());
+        damageMonster(monsterIndex, calculateTotalAttack());
 
         setWorldX(originalWorldX);
         setWorldY(originalWorldY);
@@ -463,7 +453,7 @@ public class Player extends Entity {
                 gameWindow.getSoundmanager().damageWAV("res/sound/damage-sound.wav");
 
                 // スライムのダメージ量
-                int damage = setAttack(gameWindow.getMonster()[i].getAttack() - getDefense());
+                int damage = setAttack(gameWindow.getMonster()[i].getAttack() - calculateTotalDefense());
                 if (damage < 0) {
                     damage = 0;
                 }
@@ -566,8 +556,8 @@ public class Player extends Entity {
             setMaxLife(getMaxLife() + 2);
             setStrength(getStrength() + 1);
             setDexterity(getDexterity() + 1);
-            setAttack(getAttack());
-            setDefense(getDefense());
+            setAttack(calculateBaseAttack());
+            setDefense(calculateBaseDefense());
             gameWindow.getSoundmanager().levelWAV("res/sound/level-up-sound.wav");
             gameWindow.setGameState(gameWindow.getDialogueState());
             gameWindow.getUi().setCurrentDialogueMessage("プレイヤーはレベル" + gameWindow.getPlayer().getLevel() + "になった!");
@@ -648,12 +638,38 @@ public class Player extends Entity {
         return screenY;
     }
 
-    public int getMaxInventorySize() {
-        return maxInventorySize;
-    }
-
     public ArrayList<Entity> getInventory() {
         return inventory;
+    }
+
+    public int calculateBaseAttack() {
+        return getStrength();
+    }
+
+    public int calculateWeaponBonus() {
+        return getCurrentWeapon() != null
+                ? getCurrentWeapon().getAttackValue()
+                : 1;
+    }
+
+    public int calculateTotalAttack() {
+        return calculateBaseAttack()
+                * calculateWeaponBonus();
+    }
+
+    public int calculateBaseDefense() {
+        return getDexterity();
+    }
+
+    public int calculateShieldBonus() {
+        return getCurrentShield() != null
+                ? getCurrentShield().getDefenseValue()
+                : 1;
+    }
+
+    public int calculateTotalDefense() {
+        return calculateBaseDefense()
+                * calculateShieldBonus();
     }
 
     public boolean consumeMana(int cost) {
@@ -664,7 +680,6 @@ public class Player extends Entity {
 
     public void addCoin(@NotNull ObjCoinBronze coin) {
         int value = coin.getValue();
-
         setCoin(getCoin() + value);
         gameWindow.getUi().addMessage("コインを拾った。所持金が" + value + "獲得！");
     }


### PR DESCRIPTION
# プレイヤーがレベル上がったときにスライムの石ころの衝突判定はあるが,プレイヤーの体力が減らない問題について

# Projectileクラスの`@override`updateメソッドの処理

![スクリーンショット 2025-07-05 212358](https://github.com/user-attachments/assets/01beb65e-2888-4482-9cec-d8e7947dc3c6)

# このように書いていたのですが,レベル上がったときにプレイヤーの体力がスライムの石ころの攻撃に当たっても減らないので,衝突判定がしかっりできていないものだと最初思っていました。



https://github.com/user-attachments/assets/983cd49e-bce1-42c1-9fc2-a38ecb017f43

# ですが,59行目のEntityクラスのdamagePlayerメソッドを見てみると
![スクリーンショット 2025-07-05 211647](https://github.com/user-attachments/assets/ff60f498-646f-4571-b901-b5bdfb6ae0a9)


# レベル上がる前はプレイヤーの防御力は1となっています。それに対して,スライムの石ころのダメージは2となっています。
# プレイヤーはレベルが上がると攻撃力,防御力ともに+１上がるので,レベルが3になると防御力も3になりますので,スライムの 石ころのダメージが2に対して,プレイヤーの防御力が3になるとダメージ判定は-1となり結果0になってしまうことに気づきました。