### PR TITLE
refactor: typeのsealed interface + record化とEntityへの型情報委譲

### DIFF
--- a/db/src/main/java/db/DbManager.java
+++ b/db/src/main/java/db/DbManager.java
@@ -15,23 +15,25 @@ public class DbManager {
         try (Connection conn = getConnection();
              Statement stmt = conn.createStatement()) {
 
-            // 既存の map_tile テーブル
-            stmt.execute(
-                    "CREATE TABLE IF NOT EXISTS map_tile (" +
-                            " map_id INT, x INT, y INT, tile_id INT, " +
-                            " PRIMARY KEY(map_id, x, y) )"
-            );
+            // Map 用テーブル
+            stmt.execute("""
+                    CREATE TABLE IF NOT EXISTS map_tile (
+                      map_id INT,
+                      x      INT,
+                      y      INT,
+                      tile_id INT,
+                      PRIMARY KEY(map_id, x, y)
+                    )""");
 
-            // ← ここで map_path テーブルを追加
-            stmt.execute(
-                    "CREATE TABLE IF NOT EXISTS map_path (" +
-                            " map_id   INT NOT NULL, " +
-                            " path_id  INT NOT NULL, " +
-                            " step     INT NOT NULL, " +
-                            " x        INT NOT NULL, " +
-                            " y        INT NOT NULL, " +
-                            " PRIMARY KEY(map_id, path_id, step) )"
-            );
+            stmt.execute("""
+                    CREATE TABLE IF NOT EXISTS map_path (
+                      map_id  INT NOT NULL,
+                      path_id INT NOT NULL,
+                      step    INT NOT NULL,
+                      x       INT NOT NULL,
+                      y       INT NOT NULL,
+                      PRIMARY KEY(map_id, path_id, step)
+                    )""");
         }
     }
 

--- a/java_2d_game/src/main/java/entity/AxeType.java
+++ b/java_2d_game/src/main/java/entity/AxeType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record AxeType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 4;
+    }
+
+    @Override
+    public String name() {
+        return "axe";
+    }
+}

--- a/java_2d_game/src/main/java/entity/BombType.java
+++ b/java_2d_game/src/main/java/entity/BombType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record BombType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 9;
+    }
+
+    @Override
+    public String name() {
+        return "bom";
+    }
+}

--- a/java_2d_game/src/main/java/entity/Entity.java
+++ b/java_2d_game/src/main/java/entity/Entity.java
@@ -57,17 +57,7 @@ public abstract class Entity {
     private String name;
     private boolean invincible = false;
     private int invincibleCounter = 0;
-    private int type;
-    private final int type_player = 0;
-    private final int type_npc = 1;
-    private final int type_monster = 2;
-    private final int type_sword = 3;
-    private final int type_axe = 4;
-    private final int type_shield = 5;
-    private final int type_redPotion = 6;
-    private final int type_greenPotion = 7;
-    private final int type_pickupOnly = 8;
-    private final int type_bomb = 9;
+    private EntityType type;
     private int value = 1;
     private boolean attacking = false;
     private boolean alive = true;
@@ -183,7 +173,7 @@ public abstract class Entity {
         gameWindow.getCollisionChecker().checkEntity(this, gameWindow.getItile());
         boolean contactPlayer = gameWindow.getCollisionChecker().checkPlayer(this);
 
-        if (this.type == type_monster && contactPlayer && !gameWindow.getPlayer().getInvincible()) {
+        if (getType() instanceof MonsterType && contactPlayer && !gameWindow.getPlayer().getInvincible()) {
             damagePlayer(attack);
             gameWindow.getPlayer().setInvincible(true);
         }
@@ -742,7 +732,7 @@ public abstract class Entity {
      * @throws IllegalStateException type フィールドが未設定の場合
      */
 
-    public int getType() {
+    public EntityType getType() {
         return type;
     }
 
@@ -753,7 +743,7 @@ public abstract class Entity {
      * @throws IllegalArgumentException type に負の値が渡された場合
      */
 
-    public void setType(int type) {
+    public void setType(EntityType type) {
         this.type = type;
     }
 
@@ -1267,16 +1257,6 @@ public abstract class Entity {
     }
 
     /**
-     * ピックアップ専用タイプを取得。
-     *
-     * @return type_pickupOnly ピックアップ専用を示すタイプ定数
-     */
-
-    public int getType_pickupOnly() {
-        return type_pickupOnly;
-    }
-
-    /**
      * 基本値を取得。
      *
      * @return value このエンティティの基本パラメータ値
@@ -1295,86 +1275,6 @@ public abstract class Entity {
 
     public void setValue(int value) {
         this.value = value;
-    }
-
-    /**
-     * 斧タイプ定数を取得。
-     *
-     * @return type_axe 斧を示すタイプ定数
-     */
-
-    public int getType_axe() {
-        return type_axe;
-    }
-
-    /**
-     * モンスタ―タイプ定数を取得。
-     *
-     * @return type_monster モンスターを示すタイプ定数
-     */
-
-    public int getType_monster() {
-        return type_monster;
-    }
-
-    /**
-     * プレイヤータイプ定数を取得。
-     *
-     * @return type_player プレイヤーを示すタイプ定数
-     */
-
-    public int getType_player() {
-        return type_player;
-    }
-
-    /**
-     * NPCタイプ定数を取得。
-     *
-     * @return type_npc NPCを示すタイプ定数
-     */
-
-    public int getType_npc() {
-        return type_npc;
-    }
-
-    /**
-     * 剣タイプ定数を取得。
-     *
-     * @return type_sword 剣を示すタイプ定数
-     */
-
-    public int getType_sword() {
-        return type_sword;
-    }
-
-    /**
-     * 盾タイプ定数を取得。
-     *
-     * @return type_shield 盾を示すタイプ定数
-     */
-
-    public int getType_shield() {
-        return type_shield;
-    }
-
-    /**
-     * 赤ポーションタイプ定数を取得。
-     *
-     * @return type_redPotion 赤ポーションを示すタイプ定数
-     */
-
-    public int getType_redPotion() {
-        return type_redPotion;
-    }
-
-    /**
-     * 緑ポーションタイプ定数を取得。
-     *
-     * @return type_greenPotion 緑ポーションを示すタイプ定数
-     */
-
-    public int getType_greenPotion() {
-        return type_greenPotion;
     }
 
     /**
@@ -1466,10 +1366,6 @@ public abstract class Entity {
 
     public void setPrice(int price) {
         this.price = price;
-    }
-
-    public int getType_bomb() {
-        return type_bomb;
     }
 
     /**
@@ -1658,7 +1554,7 @@ public abstract class Entity {
                 worldY > gameWindow.getPlayer().getWorldY() - gameWindow.getPlayer().getScreenY() &&
                 worldY < gameWindow.getPlayer().getWorldY() + gameWindow.getPlayer().getScreenY()) {
 
-            if (type == type_monster && hpBarOn) {
+            if (getType() instanceof MonsterType && hpBarOn) {
 
                 double oneScale = (double) FrameApp.getTileSize() / maxLife;
                 double hpBarValue = oneScale * life;

--- a/java_2d_game/src/main/java/entity/EntityType.java
+++ b/java_2d_game/src/main/java/entity/EntityType.java
@@ -1,0 +1,11 @@
+package entity;
+
+public sealed interface EntityType permits PlayerType, NpcType, MonsterType,
+        SwordType, AxeType, ShieldType,
+        RedPotionType, GreenPotionType,
+        PickupOnlyType, BombType {
+
+    int typeId();
+
+    String name();
+}

--- a/java_2d_game/src/main/java/entity/GreenPotionType.java
+++ b/java_2d_game/src/main/java/entity/GreenPotionType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record GreenPotionType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 7;
+    }
+
+    @Override
+    public String name() {
+        return "green";
+    }
+}

--- a/java_2d_game/src/main/java/entity/MonsterType.java
+++ b/java_2d_game/src/main/java/entity/MonsterType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record MonsterType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 2;
+    }
+
+    @Override
+    public String name() {
+        return "monster";
+    }
+}

--- a/java_2d_game/src/main/java/entity/NpcType.java
+++ b/java_2d_game/src/main/java/entity/NpcType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record NpcType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 1;
+    }
+
+    @Override
+    public String name() {
+        return "npc";
+    }
+}

--- a/java_2d_game/src/main/java/entity/PickupOnlyType.java
+++ b/java_2d_game/src/main/java/entity/PickupOnlyType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record PickupOnlyType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 8;
+    }
+
+    @Override
+    public String name() {
+        return "pickup";
+    }
+}

--- a/java_2d_game/src/main/java/entity/PlayerType.java
+++ b/java_2d_game/src/main/java/entity/PlayerType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record PlayerType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 0;
+    }
+
+    @Override
+    public String name() {
+        return "player";
+    }
+}

--- a/java_2d_game/src/main/java/entity/RedPotionType.java
+++ b/java_2d_game/src/main/java/entity/RedPotionType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record RedPotionType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 6;
+    }
+
+    @Override
+    public String name() {
+        return "red";
+    }
+}

--- a/java_2d_game/src/main/java/entity/ShieldType.java
+++ b/java_2d_game/src/main/java/entity/ShieldType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record ShieldType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 5;
+    }
+
+    @Override
+    public String name() {
+        return "shield";
+    }
+}

--- a/java_2d_game/src/main/java/entity/SwordType.java
+++ b/java_2d_game/src/main/java/entity/SwordType.java
@@ -1,0 +1,14 @@
+package entity;
+
+public record SwordType() implements EntityType {
+
+    @Override
+    public int typeId() {
+        return 3;
+    }
+
+    @Override
+    public String name() {
+        return "sword";
+    }
+}

--- a/java_2d_game/src/main/java/monster/MonGreenSlime.java
+++ b/java_2d_game/src/main/java/monster/MonGreenSlime.java
@@ -1,6 +1,7 @@
 package monster;
 
 import entity.Entity;
+import entity.MonsterType;
 import frame.FrameApp;
 import object.ObjStone;
 import window.GameWindow;
@@ -30,7 +31,7 @@ public class MonGreenSlime extends Entity {
     public MonGreenSlime(GameWindow gameWindow) {
 
         super(gameWindow);
-        setType(getType_monster());
+        setType(new MonsterType());
         setName("Green Slime");
         setSpeed(1);
         setMaxLife(4);

--- a/java_2d_game/src/main/java/object/ObjAxe.java
+++ b/java_2d_game/src/main/java/object/ObjAxe.java
@@ -1,5 +1,6 @@
 package object;
 
+import entity.AxeType;
 import entity.Entity;
 import frame.FrameApp;
 import window.GameWindow;
@@ -17,7 +18,7 @@ public class ObjAxe extends Entity {
         super(gameWindow);
         this.gameWindow = gameWindow;
 
-        setType(getType_axe());
+        setType(new AxeType());
         setName("木の斧");
         setAttackValue(2);
         getAttackArea().width = 25;

--- a/java_2d_game/src/main/java/object/ObjBomb.java
+++ b/java_2d_game/src/main/java/object/ObjBomb.java
@@ -1,5 +1,6 @@
 package object;
 
+import entity.BombType;
 import entity.Entity;
 import frame.FrameApp;
 import window.GameWindow;
@@ -22,7 +23,7 @@ public class ObjBomb extends Projectile {
         super(gameWindow, DIRS.length, SPRITE_COUNT);
         this.gameWindow = gameWindow;
 
-        setType(getType_bomb());
+        setType(new BombType());
         setName("爆弾");
         setSpeed(1);
         setMaxLife(80);

--- a/java_2d_game/src/main/java/object/ObjCoinBronze.java
+++ b/java_2d_game/src/main/java/object/ObjCoinBronze.java
@@ -1,6 +1,7 @@
 package object;
 
 import entity.Entity;
+import entity.PickupOnlyType;
 import frame.FrameApp;
 import window.GameWindow;
 
@@ -17,7 +18,7 @@ public class ObjCoinBronze extends Entity {
         super(gameWindow);
         this.gameWindow = gameWindow;
         setValue(1);
-        setType(getType_pickupOnly());
+        setType(new PickupOnlyType());
         setName("ブロンズコイン");
 
         try {

--- a/java_2d_game/src/main/java/object/ObjGreenPotion.java
+++ b/java_2d_game/src/main/java/object/ObjGreenPotion.java
@@ -1,6 +1,7 @@
 package object;
 
 import entity.Entity;
+import entity.GreenPotionType;
 import frame.FrameApp;
 import window.GameWindow;
 
@@ -18,7 +19,7 @@ public class ObjGreenPotion extends Entity {
     public ObjGreenPotion(GameWindow gameWindow) {
         super(gameWindow);
         this.gameWindow = gameWindow;
-        setType(getType_greenPotion());
+        setType(new GreenPotionType());
         setName("グリーンポーション");
         setDescription("[" + getName() + "]\n 魔力を20回復する");
         setPrice(10);

--- a/java_2d_game/src/main/java/object/ObjRedPotion.java
+++ b/java_2d_game/src/main/java/object/ObjRedPotion.java
@@ -1,6 +1,7 @@
 package object;
 
 import entity.Entity;
+import entity.RedPotionType;
 import frame.FrameApp;
 import window.GameWindow;
 
@@ -18,7 +19,7 @@ public class ObjRedPotion extends Entity {
     public ObjRedPotion(GameWindow gameWindow) {
         super(gameWindow);
         this.gameWindow = gameWindow;
-        setType(getType_redPotion());
+        setType(new RedPotionType());
         setName("レッドポーション");
         setDescription("[" + getName() + "]\n 体力を2回復する");
         setPrice(10);

--- a/java_2d_game/src/main/java/object/ObjShieldWood.java
+++ b/java_2d_game/src/main/java/object/ObjShieldWood.java
@@ -1,6 +1,7 @@
 package object;
 
 import entity.Entity;
+import entity.ShieldType;
 import frame.FrameApp;
 import window.GameWindow;
 
@@ -15,7 +16,7 @@ public class ObjShieldWood extends Entity {
     public ObjShieldWood(GameWindow gameWindow) {
         super(gameWindow);
         this.gameWindow = gameWindow;
-        setType(getType_shield());
+        setType(new ShieldType());
         setName("木の盾");
         setDefenseValue(1);
         setDescription("[" + getName() + "]\n 木で,できた盾");

--- a/java_2d_game/src/main/java/object/ObjSwordNormal.java
+++ b/java_2d_game/src/main/java/object/ObjSwordNormal.java
@@ -1,6 +1,7 @@
 package object;
 
 import entity.Entity;
+import entity.SwordType;
 import frame.FrameApp;
 import window.GameWindow;
 
@@ -15,7 +16,7 @@ public class ObjSwordNormal extends Entity {
     public ObjSwordNormal(GameWindow gameWindow) {
         super(gameWindow);
         this.gameWindow = gameWindow;
-        setType(getType_sword());
+        setType(new SwordType());
         setName("普通の剣");
         setAttackValue(1);
         setDescription("[" + getName() + "]\n 古くからある剣");

--- a/java_2d_game/src/main/java/player/Player.java
+++ b/java_2d_game/src/main/java/player/Player.java
@@ -1,6 +1,6 @@
 package player;
 
-import entity.Entity;
+import entity.*;
 import frame.FrameApp;
 import key.KeyHandler;
 import npc.NpcMerChant;
@@ -229,7 +229,7 @@ public class Player extends Entity {
      */
 
     private void updateCurrentAttackSprites() {
-        if (getCurrentWeapon().getType() == getType_axe()) {
+        if (getCurrentWeapon().getType() instanceof AxeType) {
             currentAttackSprites = axeSprites;
         } else {
             currentAttackSprites = attackSprites;
@@ -309,7 +309,7 @@ public class Player extends Entity {
     private void startAttack() {
 
         String base = capitalize(getDirection());
-        if (getCurrentWeapon().getType() == getType_axe()) {
+        if (getCurrentWeapon().getType() instanceof AxeType) {
             setAttackDirection("axe" + base);
         } else {
             setAttackDirection("attack" + base);
@@ -934,21 +934,21 @@ public class Player extends Entity {
             Entity selectedItem = getInventory().get(itemIndex);
             System.out.println("selectedItem = " + selectedItem);
 
-            if (selectedItem.getType() == getType_sword() || selectedItem.getType() == getType_axe()) {
+            if (selectedItem.getType() instanceof SwordType || selectedItem.getType() instanceof AxeType) {
 
                 setCurrentWeapon(selectedItem);
                 setAttack(calculateTotalAttack());
                 loadAllAttackSprites();
             }
-            if (selectedItem.getType() == getType_shield()) {
+            if (selectedItem.getType() instanceof ShieldType) {
 
                 setCurrentShield(selectedItem);
                 setDefense(calculateTotalDefense());
             }
-            if (selectedItem.getType() == getType_redPotion()) {
+            if (selectedItem.getType() instanceof RedPotionType) {
                 useRedPotion(index);
             }
-            if (selectedItem.getType() == getType_greenPotion()) {
+            if (selectedItem.getType() instanceof GreenPotionType) {
                 useGreenPotion(index);
             }
         }
@@ -1003,7 +1003,7 @@ public class Player extends Entity {
                 g2.drawImage(img, screenX, screenY, tileSize, tileSize, null);
             }
         } else {
-            boolean isAxe = getCurrentWeapon().getType() == getType_axe();
+            boolean isAxe = getCurrentWeapon().getType() instanceof AxeType;
             String[] animationKeys = isAxe
                     ? AXE_DIRECTIONS
                     : ATTACK_DIRECTIONS;

--- a/java_2d_game/src/main/java/tileInteractive/ItDryTree.java
+++ b/java_2d_game/src/main/java/tileInteractive/ItDryTree.java
@@ -1,5 +1,6 @@
 package tileInteractive;
 
+import entity.AxeType;
 import entity.Entity;
 import frame.FrameApp;
 import window.GameWindow;
@@ -26,7 +27,7 @@ public class ItDryTree extends InteractiveTile {
 
         boolean isCorrectItem = false;
 
-        if (entity.getCurrentWeapon().getType() == getType_axe()) {
+        if (entity.getCurrentWeapon().getType() instanceof AxeType) {
             isCorrectItem = true;
         }
         return isCorrectItem;

--- a/java_2d_game/src/main/java/window/GameWindow.java
+++ b/java_2d_game/src/main/java/window/GameWindow.java
@@ -21,9 +21,7 @@ import ui.UI;
 import javax.swing.*;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
+import java.util.*;
 import java.util.List;
 
 import static frame.FrameApp.baseDisplay;
@@ -62,6 +60,7 @@ public class GameWindow extends JPanel implements Window, Runnable {
     private final int debugState = 5;
     private final int gameOverState = 6;
     private final int tradeState = 7;
+    private final int saveState = 8;
     private boolean onTransition = false;
     private boolean fadingOut = true;
     private float alpha = 0f;
@@ -71,6 +70,7 @@ public class GameWindow extends JPanel implements Window, Runnable {
     private int currentMap = 1;
     private boolean showHitBoxes = false;
     private boolean dialogueActive = false;
+    private Map<String, Boolean> mapFlags = new HashMap<>();
 
     /**
      * GameWindow のコンストラクタ。
@@ -844,5 +844,38 @@ public class GameWindow extends JPanel implements Window, Runnable {
 
     public int getTradeState() {
         return tradeState;
+    }
+
+    public ArrayList<Entity> getItemList() {
+        return itemList;
+    }
+
+    public void setItemList(ArrayList<Entity> itemList) {
+        this.itemList = itemList;
+    }
+
+    public void setPlayer(Player player) {
+        this.player = player;
+    }
+
+    // マップフラグを上書きセット
+    public void setMapFlags(Map<String, Boolean> flags) {
+        // null対策してから代入するのが安全
+        if (flags == null) {
+            this.mapFlags.clear();
+        } else {
+            this.mapFlags.clear();
+            this.mapFlags.putAll(flags);
+        }
+    }
+
+    // ゲーム内から参照できるように getter も用意
+    public Map<String, Boolean> getMapFlags() {
+        return mapFlags;
+    }
+
+    // 例: マップフラグを個別に設定するヘルパー
+    public void setMapFlag(String name, boolean value) {
+        mapFlags.put(name, value);
     }
 }


### PR DESCRIPTION
# int型定数を廃止し、sealed interface + record で型定義を整理

<img width="421" height="205" alt="スクリーンショット 2025-08-25 213526" src="https://github.com/user-attachments/assets/cbae2105-d5ef-4ad9-a0f5-fae2a7ccffc5" />

# https://github.com/yanagikaito/java_game_2d_action_rpg/pull/91/files

# private EntityType type;

# Entity クラスに型情報の判定・保持を委譲し、型ごとの責務を集約


<img width="646" height="220" alt="スクリーンショット 2025-08-25 214415" src="https://github.com/user-attachments/assets/a656f1a6-522e-4b9b-bb10-be6616203573" />


<img width="528" height="314" alt="image" src="https://github.com/user-attachments/assets/b7250260-899a-4a41-a2ab-fab59550c724" />


<img width="494" height="336" alt="image" src="https://github.com/user-attachments/assets/a53766ec-3ae8-47ab-bae0-f27df81a5831" />

<img width="454" height="316" alt="image" src="https://github.com/user-attachments/assets/94fa0a85-d94f-4729-b259-bb32a82355b2" />


<img width="494" height="311" alt="image" src="https://github.com/user-attachments/assets/f9a6593f-6dd5-4687-837a-a812b4edc1c4" />


<img width="474" height="331" alt="image" src="https://github.com/user-attachments/assets/6b5896b6-c4da-4728-bf3e-978b191766a0" />

<img width="507" height="331" alt="image" src="https://github.com/user-attachments/assets/f804d002-fa71-43dd-9aa1-f8dcb916101c" />

<img width="478" height="335" alt="image" src="https://github.com/user-attachments/assets/5be3adf1-2480-4c24-9fb8-baed69573bb1" />

<img width="480" height="332" alt="image" src="https://github.com/user-attachments/assets/cad6dd87-e1b9-4a64-80d9-61b0f3ca48ae" />

# sealed interface の利点

実装クラスをコンパイル時に限定でき、型安全性が向上

switch 式で網羅性チェックが効く

# record の利点

不変データキャリアとしてシンプルに定義可能

equals/hashCode/toString を自動生成

# 責務委譲

型判定ロジックを分散させず、Entity に集約することで保守性UP

新しい型を追加する際の影響範囲を明確化