### PR TITLE
fix(save): unify UI and data slot indexing to 0-based; prevent out-of-range saves

### DIFF
--- a/java_2d_game/src/main/java/ui/UI.java
+++ b/java_2d_game/src/main/java/ui/UI.java
@@ -191,7 +191,7 @@ public class UI {
         g2.setColor(Color.WHITE);
         g2.setFont(g2.getFont().deriveFont(28F));
 
-        text = "slot1";
+        text = "slot0";
         x = getXForCenteredText(g2, text);
         y = tileSize * 2;
         g2.drawString(text, x, y);
@@ -226,7 +226,7 @@ public class UI {
         frameHeight = tileSize * 3;
         drawSubWindow(g2, frameX, frameY, frameWidth, frameHeight);
 
-        text = "slot2";
+        text = "slot1";
         x = getXForCenteredText(g2, text);
         y += (int) (tileSize * 3.5);
         g2.drawString(text, x, y);
@@ -260,7 +260,7 @@ public class UI {
         frameHeight = tileSize * 3;
         drawSubWindow(g2, frameX, frameY, frameWidth, frameHeight);
 
-        text = "slot3";
+        text = "slot2";
         x = getXForCenteredText(g2, text);
         y += (int) (tileSize * 3.5);
         g2.drawString(text, x, y);
@@ -383,27 +383,6 @@ public class UI {
         }
     }
 
-    public void confirmLoadSelectedSlot(int slotIndex) {
-        int slotNumber = slotIndex;
-        if (!SaveManager.hasSave(slotNumber)) {
-            // 空スロットのフィードバック
-            addMessage("空のスロットです");
-            return;
-        }
-
-        Entity loaded = LoadManager.loadPlayer(slotNumber, GameWindow.getInstance());
-        if (loaded != null) {
-            // ロード成功：最後にロードしたスロットを記憶
-            GameWindow.getInstance().setLastLoadedSlot(slotNumber);
-            GameWindow.getInstance().setPlayer((Player) loaded);
-            GameWindow.getInstance().setGameState(GameState.PLAY);
-        } else {
-            // ロード失敗時の処理
-            GameWindow.getInstance().setLastLoadedSlot(-1);
-            addMessage("ロードに失敗しました");
-        }
-    }
-
     public void drawDialogueLoadScreen(Graphics2D g2) {
 
         int tileSize = FrameApp.getTileSize();
@@ -421,7 +400,7 @@ public class UI {
         g2.setColor(Color.WHITE);
         g2.setFont(g2.getFont().deriveFont(28F));
 
-        text = "slot1";
+        text = "slot0";
         x = getXForCenteredText(g2, text);
         y = tileSize * 2;
         g2.drawString(text, x, y);
@@ -458,7 +437,7 @@ public class UI {
         frameHeight = tileSize * 3;
         drawSubWindow(g2, frameX, frameY, frameWidth, frameHeight);
 
-        text = "slot2";
+        text = "slot1";
         x = getXForCenteredText(g2, text);
         y += (int) (tileSize * 3.5);
         g2.drawString(text, x, y);
@@ -496,7 +475,7 @@ public class UI {
         frameHeight = tileSize * 3;
         drawSubWindow(g2, frameX, frameY, frameWidth, frameHeight);
 
-        text = "slot3";
+        text = "slot2";
         x = getXForCenteredText(g2, text);
         y += (int) (tileSize * 3.5);
         g2.drawString(text, x, y);
@@ -556,19 +535,17 @@ public class UI {
 
     // スプライトプレビュー描画ヘルパー（spriteManager を使う想定）
     private void drawSpritePreview(Graphics2D g2, SaveMeta meta, int x, int y, int w, int h) {
-        System.out.println("drawSpritePreview: meta=" + meta);
+//        System.out.println("drawSpritePreview: meta=" + meta);
         if (meta == null) {
-            System.out.println("meta is null");
+//            System.out.println("meta is null");
         } else {
-            System.out.println("key=" + meta.getSpriteKey() + ", facing=" + meta.getFacing() + ", savedAt=" + meta.getSavedAt());
+//            System.out.println("key=" + meta.getSpriteKey() + ", facing=" + meta.getFacing() + ", savedAt=" + meta.getSavedAt());
         }
-        System.out.println("spriteManager=" + spriteManager);
+//        System.out.println("spriteManager=" + spriteManager);
         BufferedImage sprite = null;
         try {
-            // spriteManager.getSprite(key, facing, frame) のような API を想定
             sprite = spriteManager.getSprite(meta.getSpriteKey(), meta.getFacing(), 0);
         } catch (Exception e) {
-            // 無ければ null のままフォールバック
         }
 
         if (sprite != null) {

--- a/java_2d_game/src/main/java/ui/state/trade/load/LoadMenuState.java
+++ b/java_2d_game/src/main/java/ui/state/trade/load/LoadMenuState.java
@@ -81,21 +81,18 @@ public class LoadMenuState implements LoadScreenState {
             if (slot == LOAD_SLOT0) {
                 System.out.println("DBG: LoadMenuState ENTER pressed, cmd=" + keyHandler.getCommandNum());
                 loadScreenContext.setState(new LoadConfirmState(loadScreenContext, slot));
-                loadScreenContext.ui().confirmLoadSelectedSlot(slot);
                 keyHandler.clearAllKeys();
                 return;
             }
             if (slot == LOAD_SLOT1) {
                 System.out.println("DBG: LoadMenuState ENTER pressed, cmd=" + keyHandler.getCommandNum());
                 loadScreenContext.setState(new LoadConfirmState(loadScreenContext, slot));
-                loadScreenContext.ui().confirmLoadSelectedSlot(slot);
                 keyHandler.clearAllKeys();
                 return;
             }
             if (slot == LOAD_SLOT2) {
                 System.out.println("DBG: LoadMenuState ENTER pressed, cmd=" + keyHandler.getCommandNum());
                 loadScreenContext.setState(new LoadConfirmState(loadScreenContext, slot));
-                loadScreenContext.ui().confirmLoadSelectedSlot(slot);
                 keyHandler.clearAllKeys();
                 return;
             }

--- a/saves/slot0.json
+++ b/saves/slot0.json
@@ -1,1 +1,1 @@
-{"exists":true,"hp":10,"maxHp":10,"facing":"down","spriteKey":"player_basic","savedAt":1782646927121,"playTimeSeconds":165}
+{"exists":true,"hp":12,"maxHp":12,"facing":"down","spriteKey":"player_basic","savedAt":1782730136801,"playTimeSeconds":236}

--- a/saves/slot2.json
+++ b/saves/slot2.json
@@ -1,1 +1,1 @@
-{"exists":true,"hp":8,"maxHp":8,"facing":"down","spriteKey":"player_basic","savedAt":1782645256014,"playTimeSeconds":62}
+{"exists":true,"hp":8,"maxHp":10,"facing":"down","spriteKey":"player_basic","savedAt":1782730088820,"playTimeSeconds":237}


### PR DESCRIPTION
## 概要
#172 で導入した互換処理／暫定対応により追加されていた `UI.confirmLoadSelectedSlot(int)` 内の処理を削除します。
このメソッド内の `slotNumber` を参照して空スロット判定を行うコードは、#173 で UI とデータのスロット基準を 0 ベースに統一したため不要になりました。

## 削除した箇所
- ファイル: `src/.../UI.java`
- メソッド: `public void confirmLoadSelectedSlot(int slotIndex)`
- 削除内容（抜粋）
```java
int slotNumber = slotIndex;
if (!SaveManager.hasSave(slotNumber)) {
    // 空スロットのフィードバック
    addMessage("空のスロットです");
    g2.drawRoundRect(cursorX, cursorY - 2, cursorWidth, cursorHeight, 10, 10);
}
```